### PR TITLE
fix `ゴーティスの朧キーフ`

### DIFF
--- a/c99529628.lua
+++ b/c99529628.lua
@@ -49,7 +49,7 @@ function s.cfilter(c)
 	return c:IsFaceup() and c:IsRace(RACE_FISH)
 end
 function s.spcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil)
+	return Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_MZONE,0,1,nil)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0


### PR DESCRIPTION
User was allowed to control no Fish monsters for it to activate its self-Summoning effect, while the opponent controlled any