### PR TITLE
fix--Mimighoul Room

### DIFF
--- a/c59293853.lua
+++ b/c59293853.lua
@@ -61,15 +61,15 @@ function s.thfilter(c)
 	return c:IsFaceup() and c:IsSetCard(0x1b7) and c:IsAbleToHand()
 end
 function s.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and s.thfilter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(s.thfilter,tp,LOCATION_MZONE,0,1,nil) end
+	if chkc then return chkc:IsLocation(LOCATION_ONFIELD) and chkc:IsControler(tp) and s.thfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(s.thfilter,tp,LOCATION_ONFIELD,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
-	local ct=Duel.GetMatchingGroupCount(s.thfilter,tp,LOCATION_MZONE,0,nil)
-	local g=Duel.SelectTarget(tp,s.thfilter,tp,LOCATION_MZONE,0,1,ct,nil)
+	local ct=Duel.GetMatchingGroupCount(s.thfilter,tp,LOCATION_ONFIELD,0,nil)
+	local g=Duel.SelectTarget(tp,s.thfilter,tp,LOCATION_ONFIELD,0,1,ct,nil)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,#g,0,0)
 end
 function s.hfilter(c,e)
-	return c:IsRelateToEffect(e) and c:IsType(TYPE_MONSTER)
+	return c:IsRelateToEffect(e)
 end
 function s.thop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(s.hfilter,nil,e)


### PR DESCRIPTION
You can banish this card from your GY, then target any number of "Mimighoul" cards you control; return them to the hand. You can only use 1 "Mimighoul Room" effect per turn, and only once that turn.
it should target "Mimighoul" cards and return them to hand 